### PR TITLE
Moving back from ST to StateP

### DIFF
--- a/Control/Proxy/Parse/Internal.hs
+++ b/Control/Proxy/Parse/Internal.hs
@@ -11,6 +11,7 @@ module Control.Proxy.Parse.Internal (
     -- * Parsing proxy transformer
     ParseP(..),
     runParseP,
+    runParseK,
 
     -- * Utilities
     get,
@@ -20,44 +21,42 @@ module Control.Proxy.Parse.Internal (
 import Control.Applicative (Applicative(pure, (<*>)))
 import Control.Monad.IO.Class(MonadIO(liftIO))
 import Control.Monad.Trans.Class(MonadTrans(lift))
-import Control.Monad.ST (ST, RealWorld, stToIO)
 import qualified Control.Proxy as P
-import Control.Proxy ((->>), (>>~), (?>=))
-import Data.STRef (STRef, newSTRef, readSTRef, writeSTRef)
-import Control.Proxy.Trans.Reader (ReaderP, runReaderP, ask)
+import Control.Proxy ((->>), (>>~), (>\\), (//>), (?>=))
+import qualified Control.Proxy.Trans.State as S
 
 -- | The 'ParseP' proxy transformer stores parsing leftovers
-newtype ParseP s i p a' a b' b m r =
-    ParseP { unParseP :: ReaderP (STRef s [Maybe i]) p a' a b' b m r }
+newtype ParseP i p a' a b' b m r =
+    ParseP { unParseP :: S.StateP [Maybe i] p a' a b' b m r }
 
 -- Deriving Functor
-instance (P.Proxy p, Monad m) => Functor (ParseP i s p a' a b' b m) where
+instance (P.Proxy p, Monad m) => Functor (ParseP i p a' a b' b m) where
     fmap f p = ParseP (fmap f (unParseP p))
 
 -- Deriving Applicative
-instance (P.Proxy p, Monad m) => Applicative (ParseP i s p a' a b' b m) where
+instance (P.Proxy p, Monad m) => Applicative (ParseP i p a' a b' b m) where
     pure r  = ParseP (pure r)
     f <*> x = ParseP (unParseP f <*> unParseP x)
 
 -- Deriving Monad
-instance (P.Proxy p, Monad m) => Monad (ParseP i s p a' a b' b m) where
+instance (P.Proxy p, Monad m) => Monad (ParseP i p a' a b' b m) where
     return = P.return_P
     (>>=)  = (?>=)
 
 -- Deriving MonadTrans
-instance (P.Proxy p) => MonadTrans (ParseP i s p a' a b' b) where
+instance (P.Proxy p) => MonadTrans (ParseP i p a' a b' b) where
     lift = P.lift_P
 
 -- Deriving MFunctor
-instance (P.Proxy p) => P.MFunctor (ParseP i s p a' a b' b) where
+instance (P.Proxy p) => P.MFunctor (ParseP i p a' a b' b) where
     hoist = P.hoist_P
 
 -- Deriving MonadIO
-instance (MonadIO m, P.Proxy p) => MonadIO (ParseP i s p a' a b' b m) where
+instance (MonadIO m, P.Proxy p) => MonadIO (ParseP i p a' a b' b m) where
     liftIO = P.liftIO_P
 
 -- Deriving ProxyInternal
-instance (P.Proxy p) => P.ProxyInternal (ParseP i s p) where
+instance (P.Proxy p) => P.ProxyInternal (ParseP i p) where
     return_P = \r -> ParseP (P.return_P r)
     m ?>= f  = ParseP (unParseP m ?>= \r -> unParseP (f r))
 
@@ -67,41 +66,51 @@ instance (P.Proxy p) => P.ProxyInternal (ParseP i s p) where
 
     liftIO_P m = ParseP (P.liftIO_P m)
 
+    thread_P p = \s -> ParseP (P.thread_P (unParseP p) s)
+
+
 -- Deriving Proxy
-instance (P.Proxy p) => P.Proxy (ParseP s i p) where
+instance (P.Proxy p) => P.Proxy (ParseP i p) where
     fb' ->> p = ParseP ((\b' -> unParseP (fb' b')) ->> unParseP p)
     p >>~ fb  = ParseP (unParseP p >>~ (\b -> unParseP (fb b)))
 
     request = \a' -> ParseP (P.request a')
     respond = \b  -> ParseP (P.respond b )
 
-instance P.ProxyTrans (ParseP s i) where
+    fb' >\\ p = ParseP ((\b' -> unParseP (fb' b')) >\\ unParseP p)
+    p //> fb  = ParseP (unParseP p //> (\b -> unParseP (fb b)))
+
+    turn p = ParseP (P.turn (unParseP p))
+
+
+instance P.ProxyTrans (ParseP i) where
     liftP p = ParseP (P.liftP p)
 
-instance P.PFunctor (ParseP s i) where
+instance P.PFunctor (ParseP i) where
     hoistP nat p = ParseP (P.hoistP nat (unParseP p))
 
--- | Unwrap a 'ParseP' proxy
-runParseP
-    :: (Monad m, P.Proxy p)
-    => (forall x . p a' a b' b (ST s) x -> p a' a b' b m x)
-    -> ParseP s i p a' a b' b m r
-    ->            p a' a b' b m r
-runParseP morph p =
-    morph (P.lift_P (newSTRef [])) ?>= \ref ->
-    runReaderP ref (unParseP p)
+{-| Evaluate a non-backtracking parser, returning the result or failing with a
+    'ParseFailure' exception.
+ -}
+runParseP :: (Monad m, P.Proxy p) => ParseP i p a' a b' b m r -> p a' a b' b m r
+runParseP p = S.evalStateP [] (unParseP p)
 {-# INLINABLE runParseP #-}
 
+{-| Evaluate a non-backtracking parser \'@K@\'leisli arrow, returning the result
+    or failing with a 'ParseFailure' exception.
+ -}
+runParseK
+    :: (Monad m, P.Proxy p)
+    => (q -> ParseP i p a' a b' b m r) -> (q -> p a' a b' b m r)
+runParseK k q = runParseP (k q)
+{-# INLINABLE runParseK #-}
+
 -- | Get the internal leftovers buffer
-get :: (P.Proxy p) => ParseP s i p a' a b' b (ST s) [Maybe i]
-get = ParseP (do
-    ref <- ask
-    lift (readSTRef ref) )
+get :: (Monad m, P.Proxy p) => ParseP i p a' a b' b m [Maybe i]
+get = ParseP S.get
 {-# INLINABLE get #-}
 
 -- | Set the internal leftovers buffer
-put :: (P.Proxy p) => [Maybe i] -> ParseP s i p a' a b' b (ST s) ()
-put s = ParseP (do
-    ref <- ask
-    lift (writeSTRef ref s) )
+put :: (Monad m, P.Proxy p) => [Maybe i] -> ParseP i p a' a b' b m ()
+put s = ParseP (S.put s)
 {-# INLINABLE put #-}

--- a/pipes-parse.cabal
+++ b/pipes-parse.cabal
@@ -33,7 +33,7 @@ Source-Repository head
 Library
     Build-Depends:
         base         >= 4       && < 5  ,
-        pipes        >= 3.2.0   && < 3.3,
+        pipes        >= 3.3     && < 3.4,
         transformers >= 0.2.0.0 && < 0.4
     Exposed-Modules:
         Control.Proxy.Parse,


### PR DESCRIPTION
I moved all the `ST` related stuff back to `StateP`, basically going back to how everything was a month ago, except now working with `pipes` 3.3.0 so that we still have global state support.

I didn't add back the functions `justP` and `justK` that were removed recently.

I haven't tested this, I just made the thing compile, hopefully helping this move forward. Feel free to discard this pull request if you had something different in mind.
