### PR TITLE
Add ParseFailure EOF constructor

### DIFF
--- a/Control/Proxy/Parse.hs
+++ b/Control/Proxy/Parse.hs
@@ -136,7 +136,8 @@ passWhile pred () = go
 
 -- | Exception indicating a parse failure.
 data ParseFailure
-   = EOF -- ^End of input stream reached.
+   = EOF                 -- ^End of input stream reached.
+   | ParseFailure String -- ^Custom error message.
    deriving (Show, Typeable)
 
 instance Exception ParseFailure


### PR DESCRIPTION
I think it will be helpful to have `ParseFailure` use explicit constructors, so that users have a better API for pattern matching against these errors. Currently, I've introduced the `EOF` constructor, but maybe in the future we'll need some others. 
