### PR TITLE
Generalize outputs

### DIFF
--- a/src/Pipes/Parse.hs
+++ b/src/Pipes/Parse.hs
@@ -205,7 +205,7 @@ intercalate sep = go0
 {-# INLINABLE intercalate #-}
 
 -- | @(take n)@ only keeps the first @n@ functor layers of a 'FreeT'
-takeFree :: (Functor f, Monad m) => Int -> FreeT f m r -> FreeT f m ()
+takeFree :: (Functor f, Monad m) => Int -> FreeT f m () -> FreeT f m ()
 takeFree = go
   where
     go n f =
@@ -213,8 +213,8 @@ takeFree = go
         then FreeT $ do
             x <- runFreeT f
             case x of
-                Pure _ -> return (Pure ())
-                Free w -> return (Free (fmap (go $! n - 1) w))
+                Pure () -> return (Pure ())
+                Free w  -> return (Free (fmap (go $! n - 1) w))
         else return ()
 {-# INLINABLE takeFree #-}
 


### PR DESCRIPTION
While working on `pipes-attoparsec` I figured the return type of some of the functions in `Pipes.Parse` could be a bit more general, making them more reusable. 

I've changed some already and I'll change some others later, each one in a single commit. I haven't tried them yet.
