### PR TITLE
Increase upper-bound on 'free' to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pipes-Parse v2.0.0
+# Pipes-Parse v2.1.0
 
 `pipes-parse` builds upon
 [the `pipes` library](https://github.com/Gabriel439/Haskell-Pipes-Library) to

--- a/pipes-parse.cabal
+++ b/pipes-parse.cabal
@@ -1,5 +1,5 @@
 Name: pipes-parse
-Version: 2.0.0
+Version: 2.1.0
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
@@ -30,7 +30,7 @@ Library
     HS-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5  ,
-        free         >= 3.1     && < 3.5,
+        free         >= 3.1     && < 4.2,
         pipes        >= 4.0     && < 4.1,
         transformers >= 0.2.0.0 && < 0.4
     Exposed-Modules: Pipes.Parse


### PR DESCRIPTION
Confirmed to build with packages in the latest NixOS tree - which uses `free` 4.1
