### PR TITLE
Fixed splitOn from hanging if you take more then one with takeFree

### DIFF
--- a/src/Pipes/Parse.hs
+++ b/src/Pipes/Parse.hs
@@ -144,6 +144,7 @@ module Pipes.Parse (
     ) where
 
 import Control.Applicative ((<$>), (<$))
+import Control.Monad (void)
 import qualified Control.Monad.Trans.Free as F
 import Control.Monad.Trans.Free (FreeF(Pure, Free), FreeT(FreeT, runFreeT))
 import qualified Control.Monad.Trans.State.Strict as S
@@ -194,15 +195,15 @@ chunksOf n = loop
 -}
 splitOn
     :: (Monad m) => (a -> Bool) -> Producer a m r -> FreeT (Producer a m) m r
-splitOn predicate = loop
+splitOn predicate = go
   where
-    loop p = do
+    go p = do
         (x, p') <- F.liftF $ runStateP p $ do
-            (Just <$> input) >-> (Nothing <$ takeWhile (not . predicate))
-            (Just <$> input) >-> (Nothing <$ for (P.take 1) discard)
+            void input >-> takeWhile (not . predicate)
+            lift draw
         case x of
-            Just r  -> return r
-            Nothing -> loop p'
+            Left  r -> return r
+            Right _ -> go p'
 {-# INLINABLE splitOn #-}
 
 -- | Join a 'FreeT'-delimited stream of 'Producer's into a single 'Producer'


### PR DESCRIPTION
SplitOn hangs with anything that takes more then 1 from FreeT. ex:

```
> runEffect $ (Pipes.Parse.concat .  splitOn (==' ') $ (each "hi you now")) >-> P.print
'h'
'i'
^CInterrupted.
```

It now closely follows splitOn from the split package.

split package:
     > concat $ splitOn " " "hi you now"
    "hiyounow"

```
> runEffect $ (Pipes.Parse.concat .  splitOn'' (==' ') $ (each "hi you now")) >-> P.print
'h'
'i'
'y'
'o'
'u'
'n'
'o'
'w'
```
