### PR TITLE
Add atEndOfInput

### DIFF
--- a/src/Pipes/Parse.hs
+++ b/src/Pipes/Parse.hs
@@ -29,6 +29,7 @@ module Pipes.Parse (
     -- * Utilities
     , toParser
     , toParser_
+    , atEndOfInput
 
     -- * Re-exports
     -- $reexports
@@ -164,7 +165,7 @@ isEndOfInput = do
 
 > Control.Foldl.purely foldAll :: Monad m => Fold a b -> Parser a m b
 -}
-foldAll 
+foldAll
     :: Monad m
     => (x -> a -> x)
     -- ^ Step function
@@ -315,6 +316,22 @@ toParser_ consumer = StateT $ \producer -> do
     return ((), return r)
 {-# INLINABLE toParser_ #-}
 
+{- | Returns @'Just' r@ if the producer has reached end of input, otherwise
+     'Nothing'.
+-}
+atEndOfInput :: Monad m => StateT (Producer a m r) m (Maybe r)
+atEndOfInput = do
+    p0 <- S.get
+    x <- lift (next p0)
+    case x of
+        Left r -> do
+            S.put (return r)
+            return (Just r)
+        Right (a,p1) -> do
+            S.put (yield a >> p1)
+            return Nothing
+{-# INLINABLE atEndOfInput #-}
+
 {- $reexports
     "Control.Monad.Trans.Class" re-exports 'lift'.
 
@@ -323,3 +340,4 @@ toParser_ consumer = StateT $ \producer -> do
 
     "Pipes" re-exports 'Producer', 'yield', and 'next'.
 -}
+


### PR DESCRIPTION
I've written this function (and variants of it) a couple of times already. In fact all of `pipes-aeson`, `pipes-binary` and `pipes-attoparsec` include their own version of this function (see here for example https://github.com/k0001/pipes-attoparsec/blob/master/src/Pipes/Attoparsec.hs#L177)

At first I hesitated about whether it was a nice idea to include this function or not as it doesn't fit in the `Parser` type, but it is really useful to have it at hand, and it is compatible with the `Parser` type after all.

If you agree to include this, then I'll submit similar tools to `pipes-bytestring` and `pipes-text` (which ignore trailing empty `Text`/`ByteString`.
