### PR TITLE
support GHC 9.0

### DIFF
--- a/src/Pipes/Parse.hs
+++ b/src/Pipes/Parse.hs
@@ -147,7 +147,7 @@ unDraw a = S.modify (yield a >>)
 peek :: Monad m => Parser a m (Maybe a)
 peek = do
     x <- draw
-    forM_ x unDraw
+    forM_ x $ \a -> unDraw a
     return x
 {-# INLINABLE peek #-}
 


### PR DESCRIPTION
one trivial change due to [simplified subsumption](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption)

Tested locally with
```
cabal build -w ghc-9.0.1
```