### PR TITLE
Allow transformers-0.6

### DIFF
--- a/pipes-parse.cabal
+++ b/pipes-parse.cabal
@@ -33,7 +33,7 @@ Library
     Build-Depends:
         base         >= 4       && < 5  ,
         pipes        >= 4.1     && < 4.4,
-        transformers >= 0.2.0.0 && < 0.6
+        transformers >= 0.2.0.0 && < 0.7
     Exposed-Modules:
         Pipes.Parse,
         Pipes.Parse.Tutorial


### PR DESCRIPTION
Tested using

```
cabal-3.10.1.0 build -w ghc-9.6.1
```

which succeeded.
